### PR TITLE
Update pygments plugin to render unrecognized code langs without high…

### DIFF
--- a/sitegen/dispatch.lua
+++ b/sitegen/dispatch.lua
@@ -22,8 +22,7 @@ do
       local callbacks = self.callbacks
       for _index_0 = 1, #parts do
         local p = parts[_index_0]
-        local _update_0 = p
-        callbacks[_update_0] = callbacks[_update_0] or { }
+        callbacks[p] = callbacks[p] or { }
         callbacks = callbacks[p]
       end
       return table.insert(callbacks, callback)

--- a/spec/plugins_spec.moon
+++ b/spec/plugins_spec.moon
@@ -122,3 +122,51 @@ $hello{[[
   print thing
   ```
 ]]}]=], out
+
+
+describe "sitegen.plugins.pygments", ->
+  local site, py
+
+  before_each ->
+    site = factory.Site {}
+    py = require("sitegen.plugins.pygments")
+
+  it "syntax highlights some code", ->
+    plugin = py site
+    out = flatten_html plugin\filter [[
+```lua
+print("hello world")
+```]]
+
+    assert.same [[<pre class="highlight lang_lua"><code><span></span><span class="nb">print</span><span class="p">(</span><span class="s2">&quot;hello world&quot;</span><span class="p">)</span></code></pre>]], out
+
+  it "doesnt highlight code inside of a cosmo template", ->
+    plugin = py site
+    out = flatten_html plugin\filter [=[
+```lua
+print 5
+```
+
+$hello{[[
+  ```lua
+  print thing
+  ```
+]]}]=]
+
+    assert.same [=[<pre class="highlight lang_lua"><code><span></span><span class="nb">print</span><span class="mi">5</span></code></pre>
+
+$hello{[[
+  ```lua
+  print thing
+  ```
+]]}]=], out
+
+  it "doesn't highlight unrecognized code languages", ->
+    plugin = py site
+    out = flatten_html plugin\filter [[
+```snickerdoodle
+this code block has an unknown label
+```]]
+
+    assert.same [[<pre class="highlight lang_snickerdoodle"><code>this code block has an unknown label
+</code></pre>]], out


### PR DESCRIPTION
…lights

When the pygments plugin calls `pygmentize` with a language it does not recognize, Pygments outputs `Error: no lexer for alias 'lang' found` and leaves the file meant to capture the result blank. This means that the value of the `out` variable, [here](https://github.com/leafo/sitegen/blob/master/sitegen/plugins/pygments.moon#L28), is equal to a blank string (`""`), and therefore, the [following `assert`](https://github.com/leafo/sitegen/blob/master/sitegen/plugins/pygments.moon#L31-L32) fails and we see the `"Failed to parse pygmentize result, is pygments installed?"` error, even though `pygments` is installed.

This change will make the pygments plugin output a warning and return the original code block, html-escaped and without highlighting, rather than failing with an error, when encountering a language Pygments does not recognize.