### PR TITLE
Fix `bad key for unescape_cosmo` error when unescaping adjacent cosmo selectors

### DIFF
--- a/sitegen/renderers/markdown.lua
+++ b/sitegen/renderers/markdown.lua
@@ -1,6 +1,6 @@
 local Renderer
 Renderer = require("sitegen.renderer").Renderer
-local dollar_temp = "0000sitegen_markdown00dollar0000"
+local dollar_temp = "z000sitegen_markdown00dollar0000"
 local simple_string
 simple_string = function(delim)
   local P

--- a/sitegen/renderers/markdown.moon
+++ b/sitegen/renderers/markdown.moon
@@ -1,6 +1,6 @@
 import Renderer from require "sitegen.renderer"
 
-dollar_temp = "0000sitegen_markdown00dollar0000"
+dollar_temp = "z000sitegen_markdown00dollar0000"
 
 -- a constructor for quote delimited strings
 simple_string = (delim) ->

--- a/spec/renderer_spec.moon
+++ b/spec/renderer_spec.moon
@@ -149,6 +149,7 @@ $markdown{[[
 
 
   describe "renderers.markdown", ->
+    import escape_cosmo, unescape_cosmo from require "sitegen.renderers.markdown"
     local site, renderer
     before_each ->
       MarkdownRenderer = require "sitegen.renderers.markdown"
@@ -177,11 +178,16 @@ $markdown{[[
         }
       } zone]]}
     }
-      import escape_cosmo, unescape_cosmo from require "sitegen.renderers.markdown"
 
       it "escapes and unescapes cosmo", ->
         escaped = escape_cosmo str
         assert.same escaped,
-          "hello 0000sitegen_markdown00dollar0000.1 zone"
+          "hello z000sitegen_markdown00dollar0000.1 zone"
         assert.same str, (unescape_cosmo escape_cosmo str)
 
+    it "escapes and unescapes adjacent cosmo selectors", ->
+      str = "$host$request_uri"
+      escaped = escape_cosmo str
+      assert.same escaped,
+        "z000sitegen_markdown00dollar0000.1z000sitegen_markdown00dollar0000.2"
+      assert.same str, (unescape_cosmo escape_cosmo str)


### PR DESCRIPTION
Adjacent cosmo selectors such as `$one$two` are escaped by the markdown renderer as

```
"0000sitegen_markdown00dollar0000.10000sitegen_markdown00dollar0000.2"
```

This presents a problem when unescaping because it is not clear where one selector ends and the other begins.

This change updates the first character to the escape phrase, `0000sitegen_markdown00dollar0000` to be the letter `z` instead of a zero `0`, to clearly demarcate escape phrases when they are not separated by white space.